### PR TITLE
implement "safe" versions of macros that will work outside repos (fixes #10)

### DIFF
--- a/git-version-macro/src/lib.rs
+++ b/git-version-macro/src/lib.rs
@@ -104,10 +104,11 @@ pub fn git_describe(input: TokenStream) -> TokenStream {
 pub fn git_describe_or_cargo_version(input: TokenStream) -> TokenStream {
 	let args: Vec<_> = parse_macro_input!(input as ArgList).args.iter().map(|x| x.value()).collect();
 
+  let cargo_version = concat!(env!("CARGO_PKG_VERSION"), "-cargo");
 	let tokens = match git_describe_impl(args) {
 		Ok(x) => x,
 		Err(_) => quote!{
-      env!("CARGO_PKG_VERSION")
+      #cargo_version
     }
 	};
 
@@ -130,10 +131,11 @@ pub fn git_version(input: TokenStream) -> TokenStream {
 pub fn git_or_cargo_version(input: TokenStream) -> TokenStream {
   parse_macro_input!(input as Nothing);
 
+  let cargo_version = concat!(env!("CARGO_PKG_VERSION"), "-cargo");
   let tokens = match git_describe_impl(&VERSION_ARGS) {
 	  Ok(x) => x,
 		Err(_) => quote!{
-      env!("CARGO_PKG_VERSION")
+      #cargo_version
     }
 	};
 

--- a/git-version-macro/src/lib.rs
+++ b/git-version-macro/src/lib.rs
@@ -101,7 +101,7 @@ pub fn git_describe(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_hack]
-pub fn git_describe_safe(input: TokenStream) -> TokenStream {
+pub fn git_describe_or_cargo_version(input: TokenStream) -> TokenStream {
 	let args: Vec<_> = parse_macro_input!(input as ArgList).args.iter().map(|x| x.value()).collect();
 
 	let tokens = match git_describe_impl(args) {
@@ -127,7 +127,7 @@ pub fn git_version(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_hack]
-pub fn git_version_safe(input: TokenStream) -> TokenStream {
+pub fn git_or_cargo_version(input: TokenStream) -> TokenStream {
   parse_macro_input!(input as Nothing);
 
   let tokens = match git_describe_impl(&VERSION_ARGS) {

--- a/git-version-macro/src/lib.rs
+++ b/git-version-macro/src/lib.rs
@@ -104,11 +104,10 @@ pub fn git_describe(input: TokenStream) -> TokenStream {
 pub fn git_describe_or_cargo_version(input: TokenStream) -> TokenStream {
 	let args: Vec<_> = parse_macro_input!(input as ArgList).args.iter().map(|x| x.value()).collect();
 
-  let cargo_version = concat!(env!("CARGO_PKG_VERSION"), "-cargo");
 	let tokens = match git_describe_impl(args) {
 		Ok(x) => x,
 		Err(_) => quote!{
-      #cargo_version
+      concat!(env!("CARGO_PKG_VERSION"), "-cargo");
     }
 	};
 
@@ -131,11 +130,10 @@ pub fn git_version(input: TokenStream) -> TokenStream {
 pub fn git_or_cargo_version(input: TokenStream) -> TokenStream {
   parse_macro_input!(input as Nothing);
 
-  let cargo_version = concat!(env!("CARGO_PKG_VERSION"), "-cargo");
   let tokens = match git_describe_impl(&VERSION_ARGS) {
 	  Ok(x) => x,
 		Err(_) => quote!{
-      #cargo_version
+      concat!(env!("CARGO_PKG_VERSION"), "-cargo");
     }
 	};
 

--- a/git-version-macro/src/lib.rs
+++ b/git-version-macro/src/lib.rs
@@ -101,12 +101,40 @@ pub fn git_describe(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_hack]
-pub fn git_version(input: TokenStream) -> TokenStream {
-	parse_macro_input!(input as Nothing);
+pub fn git_describe_safe(input: TokenStream) -> TokenStream {
+	let args: Vec<_> = parse_macro_input!(input as ArgList).args.iter().map(|x| x.value()).collect();
 
-	let tokens = match git_describe_impl(&VERSION_ARGS) {
+	let tokens = match git_describe_impl(args) {
 		Ok(x) => x,
+		Err(_) => quote!{
+      env!("CARGO_PKG_VERSION")
+    }
+	};
+
+	TokenStream::from(tokens)
+}
+
+#[proc_macro_hack]
+pub fn git_version(input: TokenStream) -> TokenStream {
+  parse_macro_input!(input as Nothing);
+
+  let tokens = match git_describe_impl(&VERSION_ARGS) {
+	  Ok(x) => x,
 		Err(e) => e.to_compile_error(),
+	};
+
+	TokenStream::from(tokens)
+}
+
+#[proc_macro_hack]
+pub fn git_version_safe(input: TokenStream) -> TokenStream {
+  parse_macro_input!(input as Nothing);
+
+  let tokens = match git_describe_impl(&VERSION_ARGS) {
+	  Ok(x) => x,
+		Err(_) => quote!{
+      env!("CARGO_PKG_VERSION")
+    }
 	};
 
 	TokenStream::from(tokens)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,10 @@ pub use git_version_macro::git_describe;
 ///
 /// For example:
 /// ```
-/// const VERSION : &str = git_version::git_describe_safe!("--always", "--dirty");
+/// const VERSION : &str = git_version::git_describe_or_cargo_version!("--always", "--dirty");
 /// ```
 #[proc_macro_hack]
-pub use git_version_macro::git_describe_safe;
+pub use git_version_macro::git_describe_or_cargo_version;
 
 /// Get the git version for the source code.
 ///
@@ -58,12 +58,12 @@ pub use git_version_macro::git_version;
 /// `CARGO_PKG_VERSION` environment variable if the code is not being
 /// built in a git repository.  The version string will be created by
 /// calling `git describe --always --dirty=-modified`.  Use
-/// [`git_describe_safe`] if you want to pass different flags to `git
+/// [`git_describe_or_cargo_version`] if you want to pass different flags to `git
 /// describe`.
 ///
 /// For example:
 /// ```
-/// const VERSION : &str = git_version::git_version_safe!();
+/// const VERSION : &str = git_version::git_or_cargo_version!();
 /// ```
 #[proc_macro_hack]
-pub use git_version_macro::git_version_safe;
+pub use git_version_macro::git_or_cargo_version;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,20 @@ use proc_macro_hack::proc_macro_hack;
 #[proc_macro_hack]
 pub use git_version_macro::git_describe;
 
+/// Invoke `git describe` at compile time with custom flags, or use the cargo version.
+///
+/// This is like [`git_describe`], but falls back on the
+/// `CARGO_PKG_VERSION` environment variable if the code is not being
+/// built in a git repository.  All arguments to the macro must be
+/// string literals, and will be passed directly to `git describe`.
+///
+/// For example:
+/// ```
+/// const VERSION : &str = git_version::git_describe_safe!("--always", "--dirty");
+/// ```
+#[proc_macro_hack]
+pub use git_version_macro::git_describe_safe;
+
 /// Get the git version for the source code.
 ///
 /// The version string will be created by calling `git describe --always --dirty=-modified`.
@@ -37,3 +51,19 @@ pub use git_version_macro::git_describe;
 /// ```
 #[proc_macro_hack]
 pub use git_version_macro::git_version;
+
+/// Get the git version or if unavailable the cargo version.
+///
+/// This is like [`git_version`], but falls back on the
+/// `CARGO_PKG_VERSION` environment variable if the code is not being
+/// built in a git repository.  The version string will be created by
+/// calling `git describe --always --dirty=-modified`.  Use
+/// [`git_describe_safe`] if you want to pass different flags to `git
+/// describe`.
+///
+/// For example:
+/// ```
+/// const VERSION : &str = git_version::git_version_safe!();
+/// ```
+#[proc_macro_hack]
+pub use git_version_macro::git_version_safe;


### PR DESCRIPTION
I called them `git_describe_safe` and `git_version_safe`.  It's a pretty simple fix, and I tested it locally, but don't see an easy way to create a cargo test that is not inside a git repository.