### PR TITLE
Parse arguments to git_version, and implement pre-/suffixes and (cargo-)fallback

### DIFF
--- a/git-version-macro/src/utils.rs
+++ b/git-version-macro/src/utils.rs
@@ -2,8 +2,6 @@ use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::process::Command;
 
-pub const VERSION_ARGS: [&str; 2] = ["--always", "--dirty=-modified"];
-
 /// Remove a trailing newline from a byte string.
 fn strip_trailing_newline(mut input: Vec<u8>) -> Vec<u8> {
 	if input.len() > 0 && input[input.len() - 1] == b'\n' {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,11 @@ use proc_macro_hack::proc_macro_hack;
 ///
 /// # Examples
 ///
-/// ```no_compile
+/// ```ignore
 /// const VERSION: &str = git_version!();
 /// ```
 ///
-/// ```no_compile
+/// ```ignore
 /// const VERSION: &str = git_version!(args = ["--abbrev=40", "-always"]);
 /// ```
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,3 +50,14 @@ use proc_macro_hack::proc_macro_hack;
 /// ```
 #[proc_macro_hack]
 pub use git_version_macro::git_version;
+
+/// Run `git describe` at compile time with custom flags.
+///
+/// This is just a short-hand for `git_version!(args = [...])`,
+/// to be backwards compatible with earlier versions of this crate.
+#[macro_export]
+macro_rules! git_describe {
+	($($args:tt)*) => {
+		$crate::git_version!(args = [$($args)*])
+	};
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,25 +15,21 @@
 
 use proc_macro_hack::proc_macro_hack;
 
-/// Invoke `git describe` at compile time with custom flags.
-///
-/// All arguments to the macro must be string literals, and will be passed directly to `git describe`.
-///
-/// For example:
-/// ```no_compile
-/// const VERSION: &str = git_describe!("--always", "--dirty");
-/// ```
-#[proc_macro_hack]
-pub use git_version_macro::git_describe;
-
 /// Get the git version for the source code.
 ///
-/// The version string will be created by calling `git describe --always --dirty=-modified`.
-/// Use [`git_describe`] if you want to pass different flags to `git describe`.
+/// The following (named) arguments can be given:
 ///
-/// For example:
+/// - `args`: The arguments to call `git describe` with.
+///   Default: `args = ["--always", "--dirty=-modified"]`
+///
+/// # Examples
+///
 /// ```no_compile
 /// const VERSION: &str = git_version!();
+/// ```
+///
+/// ```no_compile
+/// const VERSION: &str = git_version!(args = ["--abbrev=40", "-always"]);
 /// ```
 #[proc_macro_hack]
 pub use git_version_macro::git_version;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,18 @@ use proc_macro_hack::proc_macro_hack;
 /// - `args`: The arguments to call `git describe` with.
 ///   Default: `args = ["--always", "--dirty=-modified"]`
 ///
+/// - `prefix`, `suffix`:
+///   The git version will be prefixed/suffexed by these strings.
+///
+/// - `cargo_prefix`, `cargo_suffix`:
+///   If either is given, Cargo's version (given by the CARGO_PKG_VERSION
+///   environment variable) will be used if git fails instead of giving an
+///   error. It will be prefixed/suffixed by the given strings.
+///
+/// - `fallback`:
+///   If all else fails, this string will be given instead of reporting an
+///   error.
+///
 /// # Examples
 ///
 /// ```no_compile
@@ -30,6 +42,11 @@ use proc_macro_hack::proc_macro_hack;
 ///
 /// ```no_compile
 /// const VERSION: &str = git_version!(args = ["--abbrev=40", "-always"]);
+/// ```
+///
+/// ```
+/// # use git_version::git_version;
+/// const VERSION: &str = git_version!(prefix = "git:", cargo_prefix = "cargo:", fallback = "unknown");
 /// ```
 #[proc_macro_hack]
 pub use git_version_macro::git_version;

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -11,5 +11,5 @@ fn git_describe_is_right() {
 	println!("name = {}", name);
 	println!("GIT_VERSION = {}", git_version!(args = ["--always", "--dirty=-modified"]));
 	assert_eq!(git_version!(args = ["--always", "--dirty=-modified"]), name);
-	assert_eq!(git_version!(), name);
+	assert_eq!(git_version!(prefix = "[", suffix = "]"), format!("[{}]", name));
 }

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -1,4 +1,4 @@
-use git_version::git_version;
+use git_version::{git_describe, git_version};
 
 #[test]
 fn git_describe_is_right() {
@@ -11,5 +11,6 @@ fn git_describe_is_right() {
 	println!("name = {}", name);
 	println!("GIT_VERSION = {}", git_version!(args = ["--always", "--dirty=-modified"]));
 	assert_eq!(git_version!(args = ["--always", "--dirty=-modified"]), name);
+	assert_eq!(git_describe!("--always", "--dirty=-modified"), name);
 	assert_eq!(git_version!(prefix = "[", suffix = "]"), format!("[{}]", name));
 }

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -1,4 +1,4 @@
-use git_version::{git_describe, git_version};
+use git_version::git_version;
 
 #[test]
 fn git_describe_is_right() {
@@ -9,7 +9,7 @@ fn git_describe_is_right() {
 		.stdout;
 	let name = std::str::from_utf8(&vec[..vec.len() - 1]).expect("non-utf8 error?!");
 	println!("name = {}", name);
-	println!("GIT_VERSION = {}", git_describe!("--always", "--dirty=-modified"));
-	assert_eq!(git_describe!("--always", "--dirty=-modified"), name);
+	println!("GIT_VERSION = {}", git_version!(args = ["--always", "--dirty=-modified"]));
+	assert_eq!(git_version!(args = ["--always", "--dirty=-modified"]), name);
 	assert_eq!(git_version!(), name);
 }


### PR DESCRIPTION
Examples:

```rust
const VERSION: &str = git_version!();
const VERSION: &str = git_version!(args = ["--dirty", "--abbrev=40"]);
const VERSION: &str = git_version!(fallback = "unknown");
const VERSION: &str = git_version!(prefix = "git:", cargo_prefix = "cargo:");
const VERSION: &str = git_version!(suffix = "-git", cargo_suffix = "");
```

Fixes #10