### PR TITLE
Fix typo in example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ use proc_macro_hack::proc_macro_hack;
 /// ```
 ///
 /// ```ignore
-/// const VERSION: &str = git_version!(args = ["--abbrev=40", "-always"]);
+/// const VERSION: &str = git_version!(args = ["--abbrev=40", "--always"]);
 /// ```
 ///
 /// ```


### PR DESCRIPTION
There's a small typo on https://docs.rs/git-version/0.3.4/git_version/macro.git_version.html