### PR TITLE
Remove `proc_macro_hack` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-proc-macro-hack = "0.5"
 git-version-macro = { version = "=0.3.5", path = "git-version-macro" }
 
 [workspace]

--- a/git-version-macro/Cargo.toml
+++ b/git-version-macro/Cargo.toml
@@ -21,5 +21,4 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 proc-macro2 = "1.0"
-proc-macro-hack = "0.5"
 syn = "1.0"

--- a/git-version-macro/src/lib.rs
+++ b/git-version-macro/src/lib.rs
@@ -2,7 +2,6 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use proc_macro_hack::proc_macro_hack;
 use quote::{quote, ToTokens};
 use std::path::{Path, PathBuf};
 use syn::{
@@ -109,7 +108,7 @@ impl Parse for Args {
 	}
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn git_version(input: TokenStream) -> TokenStream {
 	let args = parse_macro_input!(input as Args);
 

--- a/git-version-macro/src/lib.rs
+++ b/git-version-macro/src/lib.rs
@@ -108,6 +108,39 @@ impl Parse for Args {
 	}
 }
 
+/// Get the git version for the source code.
+///
+/// The following (named) arguments can be given:
+///
+/// - `args`: The arguments to call `git describe` with.
+///   Default: `args = ["--always", "--dirty=-modified"]`
+///
+/// - `prefix`, `suffix`:
+///   The git version will be prefixed/suffexed by these strings.
+///
+/// - `cargo_prefix`, `cargo_suffix`:
+///   If either is given, Cargo's version (given by the CARGO_PKG_VERSION
+///   environment variable) will be used if git fails instead of giving an
+///   error. It will be prefixed/suffixed by the given strings.
+///
+/// - `fallback`:
+///   If all else fails, this string will be given instead of reporting an
+///   error.
+///
+/// # Examples
+///
+/// ```ignore
+/// const VERSION: &str = git_version!();
+/// ```
+///
+/// ```ignore
+/// const VERSION: &str = git_version!(args = ["--abbrev=40", "--always"]);
+/// ```
+///
+/// ```
+/// # use git_version::git_version;
+/// const VERSION: &str = git_version!(prefix = "git:", cargo_prefix = "cargo:", fallback = "unknown");
+/// ```
 #[proc_macro]
 pub fn git_version(input: TokenStream) -> TokenStream {
 	let args = parse_macro_input!(input as Args);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@
 //! These macros do not depend on libgit, but simply uses the `git` binary directly.
 //! So you must have `git` installed somewhere in your `PATH`.
 
-use proc_macro_hack::proc_macro_hack;
-
 /// Get the git version for the source code.
 ///
 /// The following (named) arguments can be given:
@@ -48,7 +46,6 @@ use proc_macro_hack::proc_macro_hack;
 /// # use git_version::git_version;
 /// const VERSION: &str = git_version!(prefix = "git:", cargo_prefix = "cargo:", fallback = "unknown");
 /// ```
-#[proc_macro_hack]
 pub use git_version_macro::git_version;
 
 /// Run `git describe` at compile time with custom flags.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,39 +13,6 @@
 //! These macros do not depend on libgit, but simply uses the `git` binary directly.
 //! So you must have `git` installed somewhere in your `PATH`.
 
-/// Get the git version for the source code.
-///
-/// The following (named) arguments can be given:
-///
-/// - `args`: The arguments to call `git describe` with.
-///   Default: `args = ["--always", "--dirty=-modified"]`
-///
-/// - `prefix`, `suffix`:
-///   The git version will be prefixed/suffexed by these strings.
-///
-/// - `cargo_prefix`, `cargo_suffix`:
-///   If either is given, Cargo's version (given by the CARGO_PKG_VERSION
-///   environment variable) will be used if git fails instead of giving an
-///   error. It will be prefixed/suffixed by the given strings.
-///
-/// - `fallback`:
-///   If all else fails, this string will be given instead of reporting an
-///   error.
-///
-/// # Examples
-///
-/// ```ignore
-/// const VERSION: &str = git_version!();
-/// ```
-///
-/// ```ignore
-/// const VERSION: &str = git_version!(args = ["--abbrev=40", "--always"]);
-/// ```
-///
-/// ```
-/// # use git_version::git_version;
-/// const VERSION: &str = git_version!(prefix = "git:", cargo_prefix = "cargo:", fallback = "unknown");
-/// ```
 pub use git_version_macro::git_version;
 
 /// Run `git describe` at compile time with custom flags.


### PR DESCRIPTION
Since [Rust 1.45](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html#stabilizing-function-like-procedural-macros-in-expressions-patterns-and-statements), procedural macros in expression position are stable, so `proc_macro_hack` is no longer needed.