### PR TITLE
Add git_version_count as a way to get the number of commits since HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 Embed git information in your code at compile-time.
 
 ```rust
-use git_version::git_version;
+use git_version::{git_version, git_version_count};
 const GIT_VERSION: &str = git_version!();
+const GIT_VERSION_COUNT: &str = git_version_count!();
 ```
 
 The version number will have a `-modified` suffix if your git worktree had

--- a/git-version-macro/src/utils.rs
+++ b/git-version-macro/src/utils.rs
@@ -16,12 +16,23 @@ where
 	I: IntoIterator<Item = S>,
 	S: AsRef<OsStr>,
 {
-	let cmd = Command::new("git")
-		.arg("describe")
-		.args(args)
-		.output()?;
+	let cmd = Command::new("git").arg("describe").args(args).output()?;
 
 	let output = verbose_command_error("git describe", cmd)?;
+	let output = strip_trailing_newline(output.stdout);
+
+	Ok(String::from_utf8_lossy(&output).to_string())
+}
+
+/// Run `git rev-list` for the current working directory with custom flags to get version count information from git.
+pub fn rev_list_cwd<I, S>(args: I) -> std::io::Result<String>
+where
+	I: IntoIterator<Item = S>,
+	S: AsRef<OsStr>,
+{
+	let cmd = Command::new("git").arg("rev-list").args(args).output()?;
+
+	let output = verbose_command_error("git rev-list", cmd)?;
 	let output = strip_trailing_newline(output.stdout);
 
 	Ok(String::from_utf8_lossy(&output).to_string())
@@ -30,9 +41,7 @@ where
 /// Get the git directory for the current working directory.
 pub fn git_dir_cwd() -> std::io::Result<PathBuf> {
 	// Run git rev-parse --git-dir, and capture standard output.
-	let cmd = Command::new("git")
-		.args(&["rev-parse", "--git-dir"])
-		.output()?;
+	let cmd = Command::new("git").args(&["rev-parse", "--git-dir"]).output()?;
 
 	let output = verbose_command_error("git rev-parse --git-dir", cmd)?;
 	let output = strip_trailing_newline(output.stdout);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,9 @@
 //! Embed git information in your code at compile-time.
 //!
 //! ```
-//! use git_version::git_version;
+//! use git_version::{git_version, git_version_count};
 //! const GIT_VERSION: &str = git_version!();
+//! const GIT_VERSION_COUNT: &str = git_version_count!();
 //! ```
 //!
 //! The version number will have a `-modified` suffix if your git worktree had
@@ -12,8 +13,8 @@
 //!
 //! These macros do not depend on libgit, but simply uses the `git` binary directly.
 //! So you must have `git` installed somewhere in your `PATH`.
-
-pub use git_version_macro::git_version;
+//!
+pub use git_version_macro::{git_version, git_version_count};
 
 /// Run `git describe` at compile time with custom flags.
 ///


### PR DESCRIPTION
I found that this is sometimes quite helpful when you can't use a hash for your version such as in Android apps.